### PR TITLE
Add simple Gemini chat mode

### DIFF
--- a/QUICK_START_GUIDE.md
+++ b/QUICK_START_GUIDE.md
@@ -61,6 +61,7 @@ Visit: **http://localhost:8082**
 
 - **Normal**: 400 words, 20-30 sources, quick insights
 - **Deep**: 800 words, 120+ sources, comprehensive analysis
+- **Simple Chat**: direct conversation with Gemini, no research
 
 ## 👀 What You'll See
 

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -19,6 +19,7 @@ interface ChatInputProps {
   uploadedFiles: UploadedFile[];
   onRemoveFile: (id: string) => void;
   isProcessing: boolean;
+  disableFileUpload?: boolean;
 }
 
 const ChatInput = ({
@@ -29,6 +30,7 @@ const ChatInput = ({
   uploadedFiles,
   onRemoveFile,
   isProcessing,
+  disableFileUpload,
 }: ChatInputProps) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -45,7 +47,7 @@ const ChatInput = ({
   return (
     <div className="p-6 border-t border-slate-700/50 bg-slate-800/30 backdrop-blur-sm">
       <div className="max-w-4xl mx-auto">
-        {uploadedFiles.length > 0 && (
+        {uploadedFiles.length > 0 && !disableFileUpload && (
           <div className="mb-4 space-y-2">
             {uploadedFiles.map((file) => (
               <div
@@ -81,29 +83,34 @@ const ChatInput = ({
             disabled={isProcessing}
           />
 
-          <input
-            type="file"
-            multiple
-            accept=".txt,.pdf,.doc,.docx"
-            onChange={onFileUpload}
-            className="hidden"
-            ref={fileInputRef}
-          />
+          {!disableFileUpload && (
+            <>
+              <input
+                type="file"
+                multiple
+                accept=".txt,.pdf,.doc,.docx"
+                onChange={onFileUpload}
+                className="hidden"
+                ref={fileInputRef}
+              />
 
-          <Button
-            variant="outline"
-            onClick={handleUploadClick}
-            className="bg-slate-700/30 border-2 border-slate-600/50 text-white hover:bg-slate-700/50 hover:border-slate-500/70 rounded-2xl px-4 py-3"
-            disabled={isProcessing}
-            type="button"
-          >
-            <Upload className="h-4 w-4" />
-          </Button>
+              <Button
+                variant="outline"
+                onClick={handleUploadClick}
+                className="bg-slate-700/30 border-2 border-slate-600/50 text-white hover:bg-slate-700/50 hover:border-slate-500/70 rounded-2xl px-4 py-3"
+                disabled={isProcessing}
+                type="button"
+              >
+                <Upload className="h-4 w-4" />
+              </Button>
+            </>
+          )}
 
           <Button
             onClick={onSendMessage}
             disabled={
-              (!message.trim() && uploadedFiles.length === 0) || isProcessing
+              (!message.trim() && (uploadedFiles.length === 0 || disableFileUpload)) ||
+              isProcessing
             }
             className="bg-gradient-to-r from-emerald-600 to-cyan-600 hover:from-emerald-700 hover:to-cyan-700 text-white rounded-2xl px-6 py-3 shadow-lg hover:shadow-xl transition-all duration-300"
           >

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -40,6 +40,7 @@ import {
   type ChatMessage,
   type UploadedFileMetadata,
 } from "@/services/chatSessionStorage";
+import { simpleChatService, type SimpleChatMessage } from "@/services/simpleChatService";
 
 interface UploadedFile {
   // For component state, includes File object
@@ -88,6 +89,8 @@ const ChatPage = () => {
   const [streamingContent, setStreamingContent] = useState("");
   const [originalQuery, setOriginalQuery] = useState("");
   const [isAutonomousMode, setIsAutonomousMode] = useState(true);
+  // normal | deep | simple chat
+  const [mode, setMode] = useState<"normal" | "deep" | "simple">("normal");
   const [viewingThinkingForMessageId, setViewingThinkingForMessageId] =
     useState<string | null>(null);
   const [retrievedThinkingStream, setRetrievedThinkingStream] = useState<
@@ -120,6 +123,7 @@ const ChatPage = () => {
           processingTimestamp: now,
         })),
         isAutonomousMode,
+        mode,
         messages: messagesWithTimestamps,
         perfectMindMapData,
         createdAt: now, // This should be set only once when creating
@@ -177,6 +181,7 @@ const ChatPage = () => {
       const {
         query,
         files,
+        mode: navMode,
         deepResearch,
         autonomousMode: navAutonomousMode,
         sessionId: existingSessionId,
@@ -195,6 +200,7 @@ const ChatPage = () => {
               ? true
               : savedSession.isAutonomousMode
           );
+          setMode(savedSession.mode || "normal");
 
           // Sort messages chronologically when loading from localStorage
           const sortedMessages = savedSession.messages.sort((a, b) => {
@@ -232,6 +238,7 @@ const ChatPage = () => {
       setIsAutonomousMode(
         navAutonomousMode === undefined ? true : navAutonomousMode
       );
+      setMode(navMode || (deepResearch ? "deep" : "normal"));
 
       // Files from navigation are now ProcessedFileInput[]
       const initialProcessedFilesFromNav: ProcessedFileInput[] = files || [];
@@ -284,11 +291,13 @@ const ChatPage = () => {
           // Create new session if no valid existing session
           const newSessionId = chatSessionStorage.createNewSession();
           setCurrentSessionId(newSessionId);
+          setMode("normal");
         }
       } else {
         // Create new session
         const newSessionId = chatSessionStorage.createNewSession();
         setCurrentSessionId(newSessionId);
+        setMode("normal");
       }
     }
   }, []); // Empty dependency array for mount only
@@ -324,7 +333,11 @@ const ChatPage = () => {
       saveChatSession();
     }, 100);
 
-    await processResearchQuery(query, currentFiles, deepResearch); // Pass ProcessedFileInput[]
+    if (mode === "simple") {
+      await processSimpleChat(query);
+    } else {
+      await processResearchQuery(query, currentFiles, deepResearch); // Pass ProcessedFileInput[]
+    }
   };
 
   const processResearchQuery = async (
@@ -493,6 +506,36 @@ const ChatPage = () => {
     }
   };
 
+  const processSimpleChat = async (query: string) => {
+    setIsProcessing(true);
+    try {
+      const history: SimpleChatMessage[] = [
+        ...messages.map((m) => ({
+          role: m.type === "user" ? "user" : "assistant",
+          content: m.content,
+        })),
+        { role: "user", content: query },
+      ];
+      const reply = await simpleChatService.sendMessage(history);
+      const aiMessage: ChatMessage = {
+        id: uuidv4(),
+        type: "ai",
+        content: reply,
+        timestamp: new Date(),
+      };
+      setMessages((prev) => [...prev, aiMessage]);
+      setIsProcessing(false);
+    } catch (error) {
+      console.error("Simple chat error:", error);
+      toast({
+        title: "Chat Error",
+        description: "Failed to get response from Gemini.",
+        variant: "destructive",
+      });
+      setIsProcessing(false);
+    }
+  };
+
   const handleSendMessage = async () => {
     if (!newMessage.trim() && uploadedFiles.length === 0) return;
     const currentQuery = newMessage; // Capture before reset
@@ -520,6 +563,10 @@ const ChatPage = () => {
     // setOriginalQuery(currentQuery);
 
     try {
+      if (mode === "simple") {
+        await processSimpleChat(currentQuery);
+        return;
+      }
       const lastAiMessage = messages.filter((m) => m.type === "ai").pop();
       if (lastAiMessage && !isAutonomousMode) {
         // Only use AIService follow-up if not in autonomous mode
@@ -631,6 +678,7 @@ const ChatPage = () => {
         setMessages(sortedMessages);
         setOriginalQuery(session.originalQuery);
         setIsAutonomousMode(session.isAutonomousMode);
+        setMode(session.mode || "normal");
         setPerfectMindMapData(session.perfectMindMapData || null);
 
         // Reset other states
@@ -677,6 +725,7 @@ const ChatPage = () => {
     // Create new session
     const newSessionId = chatSessionStorage.createNewSession();
     setCurrentSessionId(newSessionId);
+    setMode("normal");
 
     // Reset all state
     setMessages([]);
@@ -1041,14 +1090,15 @@ const ChatPage = () => {
           <ChatInput
             message={newMessage}
             onMessageChange={setNewMessage}
-            onSendMessage={handleSendMessage}
-            onFileUpload={handleChatFileUpload} // Use specific handler for ChatInput uploads
-            uploadedFiles={uploadedFiles}
-            onRemoveFile={(id) =>
-              setUploadedFiles((prev) => prev.filter((f) => f.id !== id))
-            }
-            isProcessing={isProcessing}
-          />
+          onSendMessage={handleSendMessage}
+          onFileUpload={handleChatFileUpload} // Use specific handler for ChatInput uploads
+          uploadedFiles={uploadedFiles}
+          onRemoveFile={(id) =>
+            setUploadedFiles((prev) => prev.filter((f) => f.id !== id))
+          }
+          isProcessing={isProcessing}
+          disableFileUpload={mode === "simple"}
+        />
         </div>
 
         {showMindMap && perfectMindMapData && (

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -3,7 +3,13 @@ import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Card } from "@/components/ui/card";
-import { Switch } from "@/components/ui/switch";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
 import { Upload, ArrowRight, Sparkles, Menu } from "lucide-react";
 import { toast } from "@/hooks/use-toast";
 import SuggestionCards from "@/components/home/SuggestionCards";
@@ -26,7 +32,7 @@ interface UploadedFile {
 const HomePage = () => {
   const navigate = useNavigate();
   const [query, setQuery] = useState("");
-  const [deepResearch, setDeepResearch] = useState(false);
+  const [mode, setMode] = useState<"normal" | "deep" | "simple">("normal");
   const [autonomousMode] = useState(true); // Always use autonomous mode
   const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -190,7 +196,7 @@ const HomePage = () => {
       state: {
         query,
         files: processedFilesForChat, // Pass the new array
-        deepResearch,
+        mode,
         autonomousMode,
       },
     });
@@ -270,19 +276,33 @@ const HomePage = () => {
                 <div className="flex items-center justify-between flex-wrap gap-6">
                   <div className="flex items-center space-x-8">
                     <div className="flex items-center space-x-3">
-                      <Switch
-                        checked={deepResearch}
-                        onCheckedChange={setDeepResearch}
-                        className="data-[state=checked]:bg-gradient-to-r data-[state=checked]:from-emerald-500 data-[state=checked]:to-cyan-500"
-                      />
+                      <Select
+                        value={mode}
+                        onValueChange={(val) => setMode(val as "normal" | "deep" | "simple")}
+                      >
+                        <SelectTrigger className="w-40">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="normal">Normal Research</SelectItem>
+                          <SelectItem value="deep">Deep Research</SelectItem>
+                          <SelectItem value="simple">Simple Chat</SelectItem>
+                        </SelectContent>
+                      </Select>
                       <div className="flex flex-col">
                         <span className="text-white font-medium">
-                          {deepResearch ? "Deep Research" : "Normal Research"}
+                          {mode === "deep"
+                            ? "Deep Research"
+                            : mode === "normal"
+                            ? "Normal Research"
+                            : "Simple Chat"}
                         </span>
                         <span className="text-xs text-slate-400">
-                          {deepResearch
+                          {mode === "deep"
                             ? "800 words, 120-140+ sources"
-                            : "400 words, 20-30 sources"}
+                            : mode === "normal"
+                            ? "400 words, 20-30 sources"
+                            : "Chat with Gemini"}
                         </span>
                       </div>
                     </div>

--- a/src/services/chatSessionStorage.ts
+++ b/src/services/chatSessionStorage.ts
@@ -142,6 +142,8 @@ export interface ChatSessionSummary {
   hasMindMap: boolean;
   hasThinking: boolean;
   isAutonomous: boolean;
+  /** Mode of the session: Normal, Deep, or Simple chat. */
+  mode?: "normal" | "deep" | "simple";
   // Enhanced metadata
   topicCount?: number;
   relevanceScore?: number;
@@ -185,6 +187,8 @@ export interface ChatSession {
   originalQuery: string;
   uploadedFileMetadata?: UploadedFileMetadata[];
   isAutonomousMode: boolean;
+  /** Session interaction mode. */
+  mode: "normal" | "deep" | "simple";
   messages: ChatMessage[];
   // Perfect mind map data
   perfectMindMapData?: PerfectMindMapData | null;
@@ -266,6 +270,7 @@ class ChatSessionStorageService {
           (msg) => msg.type === "ai" && (msg.thinkingStreamData || msg.thinking)
         ),
         isAutonomous: session.isAutonomousMode, // Enhanced metadata
+        mode: session.mode,
         topicCount: session.perfectMindMapData?.nodes?.length || 0,
         relevanceScore: this.calculateSessionRelevanceScore(session),
         mindMapVersion: "2.0",
@@ -584,6 +589,7 @@ class ChatSessionStorageService {
       id: sessionId,
       originalQuery: "",
       isAutonomousMode: false,
+      mode: "normal",
       messages: [],
       createdAt: new Date(),
       lastUpdated: new Date(),

--- a/src/services/simpleChatService.ts
+++ b/src/services/simpleChatService.ts
@@ -1,0 +1,53 @@
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import { generateText } from "ai";
+
+/**
+ * Chat message format used by the Simple Chat service.
+ */
+export interface SimpleChatMessage {
+  role: "user" | "assistant" | "system";
+  content: string;
+}
+
+/**
+ * A lightweight wrapper around the Gemini API for basic chat functionality.
+ */
+class SimpleChatService {
+  private provider: ReturnType<typeof createGoogleGenerativeAI> | null = null;
+
+  constructor() {
+    const apiKey = (import.meta.env as { VITE_GOOGLE_AI_API_KEY?: string }).VITE_GOOGLE_AI_API_KEY;
+    if (apiKey) {
+      this.provider = createGoogleGenerativeAI({ apiKey });
+      console.log("SimpleChatService initialized with Gemini");
+    } else {
+      console.warn("Gemini API key missing. Simple chat disabled.");
+    }
+  }
+
+  /**
+   * Send a chat request to Gemini using the provided message history.
+   * @param messages Ordered array of chat messages forming the conversation.
+   * @returns The assistant's reply text.
+   */
+  async sendMessage(messages: SimpleChatMessage[]): Promise<string> {
+    if (!this.provider) {
+      throw new Error("Gemini provider not initialized");
+    }
+
+    try {
+      const result = await generateText({
+        model: this.provider("gemini-pro"),
+        messages,
+        maxTokens: 1024,
+        temperature: 0.7,
+      });
+      return result.text.trim();
+    } catch (error) {
+      console.error("SimpleChatService error:", error);
+      throw error;
+    }
+  }
+}
+
+export const simpleChatService = new SimpleChatService();


### PR DESCRIPTION
## Summary
- support third chat mode using Gemini
- store session `mode` in chat session storage
- add mode selector on HomePage
- disable file uploads for simple chat
- implement basic Gemini chat service
- document new mode in Quick Start guide

## Testing
- `npm run lint` *(fails: 178 problems)*
- `npm run build` *(fails: useParams not exported)*

------
https://chatgpt.com/codex/tasks/task_b_684f08c4e584832d8f6f32f175ab838d